### PR TITLE
added ability to use masked ('XXXX') exp date when updating cim payment ...

### DIFF
--- a/lib/authorize_net/xml_transaction.rb
+++ b/lib/authorize_net/xml_transaction.rb
@@ -220,7 +220,7 @@ module AuthorizeNet
         # convert MMYY expiration dates into the XML equivalent
         unless value.nil?
           begin
-            return Date.strptime(value.to_s, '%m%y').strftime('%Y-%m')
+            return value.to_s.downcase == 'xxxx' ? 'XXXX' : Date.strptime(value.to_s, '%m%y').strftime('%Y-%m')
           rescue
             # If we didn't get the exp_date in MMYY format, try our best to convert it
             return Date.parse(value.to_s).strftime('%Y-%m')

--- a/spec/cim_spec.rb
+++ b/spec/cim_spec.rb
@@ -197,6 +197,18 @@ describe AuthorizeNet::CIM::Transaction do
       response.success?.should be_true
     end
     
+    it "should be able to update payment profiles with a masked exp date" do
+      @payment_profile.cust_type = :business
+
+      transaction = AuthorizeNet::CIM::Transaction.new(@api_login, @api_key, :gateway => :sandbox)
+      transaction.should respond_to(:update_payment_profile)
+      @credit_card_with_masked_exp_date = AuthorizeNet::CreditCard.new('4111111111111111', 'XXXX')
+      @payment_profile.payment_method = @credit_card_with_masked_exp_date
+      
+      response = transaction.update_payment_profile(@payment_profile, @profile)
+      response.success?.should be_true
+    end
+    
     it "should be able to validate payment profiles" do
       @payment_profile.cust_type = :business
 


### PR DESCRIPTION
...profile

I added a test in the cim_spec.rb file to show that this really was a bug, ran the tests, and it failed. Then I updated the code in xml_transaction.rb to fix the bug.  Then I ran the tests again, and the tests passed.
