### PR TITLE
Add Gemfile that points to gemspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Gemfile.lock
+spec/credentials.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/authorizenet.gemspec
+++ b/authorizenet.gemspec
@@ -10,5 +10,12 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("{lib}/**/*")
   s.homepage = "https://github.com/AuthorizeNet/sdk-ruby"
   s.license = "https://github.com/AuthorizeNet/sdk-ruby/blob/master/license.txt"
-  s.add_runtime_dependency "nokogiri", "~> 1.4", ">= 1.4.3"
+
+  s.required_ruby_version     = '>= 1.8.7'
+  s.required_rubygems_version = '>= 1.3.6'
+
+  s.add_runtime_dependency "nokogiri", ">= 1.4.3", "< 1.6"
+
+  s.add_development_dependency 'rake', '~> 0.8', '>= 0.8.7'
+  s.add_development_dependency 'rspec', '~> 2.1'
 end


### PR DESCRIPTION
Also add required Ruby and gems' versions to the gemspec file (as specified in README.md).

Note that Nokogiri 1.6 can't be used with Ruby versions older than 1.9.2 so the upper version is limited to 1.6 (or Ruby version requirement needs to be bumped up).
