### PR TITLE
Use Digest instead of deprecated Digest::Digest

### DIFF
--- a/lib/authorize_net/aim/response.rb
+++ b/lib/authorize_net/aim/response.rb
@@ -4,8 +4,8 @@ module AuthorizeNet::AIM
   class Response < AuthorizeNet::KeyValueResponse
     
     # Our MD5 digest generator.
-    @@digest = OpenSSL::Digest::Digest.new('md5')
-    
+    @@digest = OpenSSL::Digest.new('md5')
+
     include AuthorizeNet::AIM::Fields
     
     # Fields to convert to/from booleans.     

--- a/lib/authorize_net/sim/response.rb
+++ b/lib/authorize_net/sim/response.rb
@@ -5,8 +5,8 @@ module AuthorizeNet::SIM
   class Response < AuthorizeNet::KeyValueResponse
     
     # Our MD5 digest generator.
-    @@digest = OpenSSL::Digest::Digest.new('md5')
-    
+    @@digest = OpenSSL::Digest.new('md5')
+
     include AuthorizeNet::SIM::Fields
     
     # Constructs a new response object from a +raw_response+. Provides utility methods

--- a/lib/authorize_net/sim/transaction.rb
+++ b/lib/authorize_net/sim/transaction.rb
@@ -7,8 +7,8 @@ module AuthorizeNet::SIM
     RANDOM_SEQUENCE_MAX = (1 << 32) - 1
     
     # Our MD5 digest generator.
-    @@digest  = OpenSSL::Digest::Digest.new('md5')
-    
+    @@digest  = OpenSSL::Digest.new('md5')
+
     # The default options for the constructor.
     @@option_defaults = {
       :sequence => nil,


### PR DESCRIPTION
OpenSSL::Digest::Digest was provided for backwards compatibility, but has been deprecated in Ruby 2.1.0 giving warnings: ruby/ruby#446

Note that the following specs are failing, but they were failing even before this change:

```
rspec ./spec/aim_spec.rb:222 # AuthorizeNet::AIM::Transaction should be able to run a card present purchase with track 1 data
rspec ./spec/aim_spec.rb:229 # AuthorizeNet::AIM::Transaction should be able to run a card present purchase with LRC codes in the track 1 data
rspec ./spec/aim_spec.rb:236 # AuthorizeNet::AIM::Transaction should be able to run a card present purchase with no LRC or Start/End Sentinels in track 1 data
rspec ./spec/aim_spec.rb:243 # AuthorizeNet::AIM::Transaction should be able to run a card present purchase with track 2 data
rspec ./spec/aim_spec.rb:250 # AuthorizeNet::AIM::Transaction should be able to run a card present purchase with LRC codes in the track 2 data
rspec ./spec/aim_spec.rb:257 # AuthorizeNet::AIM::Transaction should be able to run a card present purchase with no LRC or Start/End Sentinels in track 2 data
rspec ./spec/aim_spec.rb:271 # AuthorizeNet::AIM::Transaction should be able to validate the passed MD5 hash for card present transactions
```

Seeing that they are all related to cart present transactions it may be related to my account.
