### PR TITLE
Fix unlimited for subscription total occurrences

### DIFF
--- a/lib/authorize_net/arb/subscription.rb
+++ b/lib/authorize_net/arb/subscription.rb
@@ -25,12 +25,12 @@ module AuthorizeNet::ARB
     
     attr_accessor :name, :length, :unit, :start_date, :total_occurrences, :trial_occurrences, :amount, :trial_amount, :invoice_number, :description, :subscription_id, :credit_card, :billing_address, :shipping_address, :customer
     
-    # Override the length setter to provide support for :unlimited shortcut. Do not document this method in rdoc.
-    def length=(new_length) #:nodoc:
-      if new_length == :unlimited
-        @length = UNLIMITED_OCCURRENCES
+    # Override the total_occurrences setter to provide support for :unlimited shortcut.
+    def total_occurrences=(new_total_occurrences) #:nodoc:
+      if new_total_occurrences == :unlimited
+        @total_occurrences = UNLIMITED_OCCURRENCES
       else
-        @length = new_length
+        @total_occurrences = new_total_occurrences
       end
     end
     

--- a/spec/arb_spec.rb
+++ b/spec/arb_spec.rb
@@ -153,12 +153,12 @@ describe AuthorizeNet::ARB::Subscription do
     end
   end
   
-  it "should support connivence values for unlimited subscription length" do
-    subscription = AuthorizeNet::ARB::Subscription.new(:length => :unlimited)
-    subscription.length.should == AuthorizeNet::ARB::Subscription::UNLIMITED_OCCURRENCES
+  it "should support connivence values for unlimited subscription total occurrences" do
+    subscription = AuthorizeNet::ARB::Subscription.new(:total_occurrences => :unlimited)
+    subscription.total_occurrences.should == AuthorizeNet::ARB::Subscription::UNLIMITED_OCCURRENCES
     subscription = AuthorizeNet::ARB::Subscription.new()
-    subscription.length = :unlimited
-    subscription.length.should == AuthorizeNet::ARB::Subscription::UNLIMITED_OCCURRENCES
+    subscription.total_occurrences = :unlimited
+    subscription.total_occurrences.should == AuthorizeNet::ARB::Subscription::UNLIMITED_OCCURRENCES
   end
   
   it "should support connivence values for day interval units" do


### PR DESCRIPTION
Subscription API reference and readme suggests that unlimited can be total occurrences, but code allowed to set unlimited value for length property.
