### PR TITLE
Update ADDRESS_ENTITY_DESCRIPTION

### DIFF
--- a/lib/authorize_net/fields.rb
+++ b/lib/authorize_net/fields.rb
@@ -560,7 +560,7 @@ module AuthorizeNet
           {:firstName => :first_name},
           {:lastName => :last_name},
           {:company => :company},
-          {:address => :address},
+          {:address => :street_address},
           {:city => :city},
           {:state => :state},
           {:zip => :zip},


### PR DESCRIPTION
Since AuthorizeNet::Address has field street_address, that eventually serializes as address, it would be proper to deserialize it properly, so the data is not lost.