### PR TITLE
Fix populating of street address

### DIFF
--- a/lib/authorize_net/addresses/address.rb
+++ b/lib/authorize_net/addresses/address.rb
@@ -5,14 +5,14 @@ module AuthorizeNet
     
     include AuthorizeNet::Model
     
-    attr_accessor :first_name, :last_name, :company, :street_address, :city, :state, :zip, :country, :phone, :fax, :customer_address_id
+    attr_accessor :first_name, :last_name, :company, :address, :city, :state, :zip, :country, :phone, :fax, :customer_address_id
     
     def to_hash
       hash = {
         :first_name => @first_name,
         :last_name => @last_name,
         :company => @company,
-        :address => @street_address,
+        :address => @address,
         :city => @city,
         :state => @state,
         :zip => @zip,


### PR DESCRIPTION
The street address is not being correctly populated when fields are being created for entities such as Billing Address (AKA Bill_to). The reason for this is that the field is being mapped as 'address' not 'street_address'. This change accounts for the field mappings.