### PR TITLE
Allows the use of strings as convenient gateway options

### DIFF
--- a/lib/authorize_net/xml_transaction.rb
+++ b/lib/authorize_net/xml_transaction.rb
@@ -76,13 +76,13 @@ module AuthorizeNet
       options = @@option_defaults.merge(options)
       @verify_ssl = options[:verify_ssl]
       @reference_id = options[:reference_id]
-      case options[:gateway]
-      when :sandbox, :test
-        @gateway = Gateway::TEST
-      when :production, :live
-        @gateway = Gateway::LIVE
+      @gateway = case options[:gateway].to_s
+      when 'sandbox', 'test'
+        Gateway::TEST
+      when 'production', 'live'
+        Gateway::LIVE
       else
-        @gateway = options[:gateway]
+        options[:gateway]
       end
     end
     

--- a/spec/arb_spec.rb
+++ b/spec/arb_spec.rb
@@ -50,7 +50,11 @@ describe AuthorizeNet::ARB::Transaction do
   it "should know if its running against the sandbox or not" do
     transaction = AuthorizeNet::ARB::Transaction.new(@api_login, @api_key, :gateway => :sandbox)
     transaction.test?.should be_truthy
+    transaction = AuthorizeNet::ARB::Transaction.new(@api_login, @api_key, :gateway => 'sandbox')
+    transaction.test?.should be_truthy
     transaction = AuthorizeNet::ARB::Transaction.new(@api_login, @api_key, :gateway => :live)
+    transaction.test?.should be_falsey
+    transaction = AuthorizeNet::ARB::Transaction.new(@api_login, @api_key, :gateway => 'live')
     transaction.test?.should be_falsey
     transaction = AuthorizeNet::ARB::Transaction.new(@api_login, @api_key, :gateway => 'moose')
     transaction.test?.should be_truthy

--- a/spec/cim_spec.rb
+++ b/spec/cim_spec.rb
@@ -45,7 +45,11 @@ describe AuthorizeNet::CIM::Transaction do
   it "should know if its running against the sandbox or not" do
     transaction = AuthorizeNet::CIM::Transaction.new(api_login, api_key, :gateway => :sandbox)
     expect(transaction.test?).to eq true
+    transaction = AuthorizeNet::CIM::Transaction.new(api_login, api_key, :gateway => 'sandbox')
+    expect(transaction.test?).to eq true
     transaction = AuthorizeNet::CIM::Transaction.new(api_login, api_key, :gateway => :live)
+    expect(transaction.test?).to eq false
+    transaction = AuthorizeNet::CIM::Transaction.new(api_login, api_key, :gateway => 'live')
     expect(transaction.test?).to eq false
     transaction = AuthorizeNet::CIM::Transaction.new(api_login, api_key, :gateway => 'moose')
     expect(transaction.test?).to eq true


### PR DESCRIPTION
I was using YAML to configure the gateway, and found that I had to convert the gateway option from a string to a symbol in order for the transaction to work. This PR will recognize either a string or a symbol making the convenience symbols that much more convenient.