### PR TITLE
Fixes order building from a Reporting::Response

### DIFF
--- a/lib/authorize_net/order.rb
+++ b/lib/authorize_net/order.rb
@@ -5,7 +5,10 @@ module AuthorizeNet
     
     include AuthorizeNet::Model
     
-    attr_accessor :invoice_num, :description, :tax, :tax_name, :tax_description, :freight, :freight_name, :freight_description, :duty, :duty_name, :duty_description, :tax_exempt, :po_num, :line_items
+    attr_accessor :invoice_num, :description, :tax, :tax_name, :tax_description, 
+                  :tax_exempt, :freight, :freight_name, :freight_description, 
+                  :duty, :duty_name, :duty_description, :tax_exempt, :po_num,
+                  :line_items
     
     def add_line_item(id = nil, name = nil, description = nil, quantity = nil, price = nil, taxable = nil)
       if id.kind_of?(AuthorizeNet::LineItem)

--- a/lib/authorize_net/reporting/response.rb
+++ b/lib/authorize_net/reporting/response.rb
@@ -80,7 +80,7 @@ module AuthorizeNet::Reporting
         unless tax.nil?
           transaction.order ||= AuthorizeNet::Order.new()
           tax_amount = node_content_unless_nil(tax.at_css('amount'))
-          transaction.order.tax_amount = value_to_decimal(tax_amount) unless tax_amount.nil?
+          transaction.order.tax = value_to_decimal(tax_amount) unless tax_amount.nil?
           transaction.order.tax_name = node_content_unless_nil(tax.at_css('name'))
           transaction.order.tax_description = node_content_unless_nil(tax.at_css('description'))
         end
@@ -89,16 +89,16 @@ module AuthorizeNet::Reporting
         unless shipping.nil?
           transaction.order ||= AuthorizeNet::Order.new()
           shipping_amount = node_content_unless_nil(shipping.at_css('amount'))
-          transaction.order.shipping_amount = value_to_decimal(shipping_amount) unless shipping_amount.nil?
-          transaction.order.shipping_name = node_content_unless_nil(shipping.at_css('name'))
-          transaction.order.shipping_description = node_content_unless_nil(shipping.at_css('description'))
+          transaction.order.freight = value_to_decimal(shipping_amount) unless shipping_amount.nil?
+          transaction.order.freight_name = node_content_unless_nil(shipping.at_css('name'))
+          transaction.order.freight_description = node_content_unless_nil(shipping.at_css('description'))
         end
         
         duty = @transaction.at_css('duty')
         unless duty.nil?
           transaction.order ||= AuthorizeNet::Order.new()
           duty_amount = node_content_unless_nil(duty.at_css('amount'))
-          transaction.order.duty_amount = value_to_decimal(duty_amount) unless duty_amount.nil?
+          transaction.order.duty = value_to_decimal(duty_amount) unless duty_amount.nil?
           transaction.order.duty_name = node_content_unless_nil(duty.at_css('name'))
           transaction.order.duty_description = node_content_unless_nil(duty.at_css('description'))
         end


### PR DESCRIPTION
The methods used to rebuild the order didn't use the Order's
public API correctly. This commit makes the builder match the
Order's public API.

Also added `tax_exempt` to the Order's public API since it was being
used in the builder and didn't already exist.