### PR TITLE
Adds `invoice_number` to the `Order#to_hash` return value

### DIFF
--- a/lib/authorize_net/order.rb
+++ b/lib/authorize_net/order.rb
@@ -6,6 +6,9 @@ module AuthorizeNet
     include AuthorizeNet::Model
     
     attr_accessor :invoice_num, :description, :tax, :tax_name, :tax_description, :freight, :freight_name, :freight_description, :duty, :duty_name, :duty_description, :tax_exempt, :po_num, :line_items
+
+    alias_method :invoice_number , :invoice_num
+    alias_method :invoice_number=, :invoice_num=
     
     def add_line_item(id = nil, name = nil, description = nil, quantity = nil, price = nil, taxable = nil)
       if id.kind_of?(AuthorizeNet::LineItem)
@@ -19,6 +22,7 @@ module AuthorizeNet
     def to_hash
       hash = {
         :invoice_num => @invoice_num,
+        :invoice_number => @invoice_num,
         :description => @description,
         :tax => @tax,
         :tax_name => @tax_name,


### PR DESCRIPTION
I found that the Invoice Number wasn't being updated on the server
when calling `CIM::Transaction#create_transaction_auth_only` with
and `Order` object. Upon reviewing the documentation, the correct key
for the Invoice Number is `invoice_number`, not `invoice_num`.

This commit keeps `invoice_num` and creates an `invoice_number` 
alias to preserve backwards compatibility.