### PR TITLE
match the invoiceNumber to the proper Order field name

### DIFF
--- a/lib/authorize_net/fields.rb
+++ b/lib/authorize_net/fields.rb
@@ -390,7 +390,7 @@ module AuthorizeNet
         {:bankRoutingNumberMasked => :bank_aba_code_masked},
         {:bankAccountNumberMasked => :bank_acct_num_masked},
         {:order => [
-          {:invoiceNumber => :invoice_number},
+          {:invoiceNumber => :invoice_num},
           {:description => :description},
           {:purchaseOrderNumber => :po_num}
         ]},


### PR DESCRIPTION
This attempts to fix #41 

I'm not familiar with what side effects this change may have. However it resolves the issue for me when using the CIM integration. 

BTW, I ran the specs locally several times and I get 11 errors with or without this change. Is this possibly due to my sandbox account not being properly set up for these specs?