### PR TITLE
Replace duplicated hash key

### DIFF
--- a/lib/authorize_net/reporting/returned_item.rb
+++ b/lib/authorize_net/reporting/returned_item.rb
@@ -25,7 +25,7 @@ module AuthorizeNet::Reporting
       if id.kind_of?(AuthorizeNet::Reporting::ReturnedItem)
         returned_item = id
       else
-        returned_item = AuthorizeNet::Reporting::ReturnedItem.new({:return_item_id => id, :return_item_date_utc => date_utc, :return_item_date_utc => date_local, :return_item_code => code, :line_item_description => description})
+        returned_item = AuthorizeNet::Reporting::ReturnedItem.new({:return_item_id => id, :return_item_date_utc => date_utc, :return_item_date_local => date_local, :return_item_code => code, :line_item_description => description})
       end
       @returned_items = @returned_items.to_a << returned_item
     end


### PR DESCRIPTION
As reported in issues #37 and #40, `return_item_date_utc` is duplicated in `AuthorizeNet::Reporting::ReturnedItem#add_returned_item`. The way it's setup now, `return_item_date_utc` will be set to `date_local` and the utc date will not be set. This also produces a duplicated key warning when the gem is used in Rails app.

Pull Request #30 tries to address the issue, but it also includes other changes. In this pull request, I'm simply adding a change to remove the duplicated key. I'm not sure what the intended behavior is, but it looks like both `return_item_date_utc` and `return_item_date_local` should be set to their respective values.