### PR TITLE
Fixes attaching line items to order

### DIFF
--- a/lib/authorize_net/line_item.rb
+++ b/lib/authorize_net/line_item.rb
@@ -13,7 +13,7 @@ module AuthorizeNet
         :line_item_name => @name,
         :line_item_description => @description,
         :line_item_quantity => @quantity,
-        :line_item_price => @price,
+        :line_item_unit_price => @price,
         :line_item_taxable => @taxable
       }
       hash.delete_if {|k, v| v.nil?}

--- a/lib/authorize_net/order.rb
+++ b/lib/authorize_net/order.rb
@@ -11,7 +11,7 @@ module AuthorizeNet
       if id.kind_of?(AuthorizeNet::LineItem)
         line_item = id
       else
-        line_item = AuthorizeNet::LineItem.new({:line_item_id => id, :line_item_name => name, :line_item_description => description, :line_item_quantity => quantity, :line_item_price => price, :line_item_taxable => taxable})
+        line_item = AuthorizeNet::LineItem.new({:id => id, :name => name, :description => description, :quantity => quantity, :price => price, :taxable => taxable})
       end
       @line_items = @line_items.to_a << line_item
     end


### PR DESCRIPTION
I notice that when i create an order, the confirmation email to the customer doesn't display the line items attached.

Looking at the order class and how it works to add a new line item, i saw this: 

```ruby
AuthorizeNet::LineItem.new({
  :line_item_id => id, :line_item_name => name, :line_item_description => description,
  :line_item_quantity => quantity, :line_item_price => price, :line_item_taxable => taxable
})
```

But the line item class has the following attributes:

```ruby
class LineItem
  include AuthorizeNet::Model
  attr_accessor :id, :name, :description, :quantity, :price, :taxable
```

So, I modify the Order and LineItem classes to rename those fields.

When I perform the purchase operation creating the CIM transaction, the following error was thrown:

```text
message_code: E00003
message_text: The element 'lineItems' in namespace 'AnetApi/xml/v1/schema/AnetApiSchema.xsd' has incomplete content. List of possible elements expected: 'unitPrice' in namespace 'AnetApi/xml/v1/schema/AnetApiSchema.xsd'.
```

Then, i change the to_hash() method in the line item class, and renames the line_item_price field to line_item_unit_price. And that's all, it works :)