### PR TITLE
Update member variable names in SecureAcceptance class.

### DIFF
--- a/lib/authorize_net/api/schema.rb
+++ b/lib/authorize_net/api/schema.rb
@@ -2063,12 +2063,12 @@ end
     #   payerID - SOAP::SOAPString
     class SecureAcceptance
       include ROXML
-      xml_accessor :secureAcceptanceUrl
-      xml_accessor :payerID
+      xml_accessor :SecureAcceptanceUrl
+      xml_accessor :PayerID
   
       def initialize(secureAcceptanceUrl = nil, payerID = nil)
-        @secureAcceptanceUrl = secureAcceptanceUrl
-        @payerID = payerID
+        @SecureAcceptanceUrl = secureAcceptanceUrl
+        @PayerID = payerID
       end
     end
   

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -393,8 +393,8 @@ describe Transaction do
     expected.shipTo.zip.should == actual.shipTo.zip
     expected.shipTo.country.should == actual.shipTo.country
     
-    expected.secureAcceptance.secureAcceptanceUrl.should == actual.secureAcceptance.secureAcceptanceUrl
-    expected.secureAcceptance.payerID.should == actual.secureAcceptance.payerID
+    expected.secureAcceptance.SecureAcceptanceUrl.should == actual.secureAcceptance.SecureAcceptanceUrl
+    expected.secureAcceptance.PayerID.should == actual.secureAcceptance.PayerID
 
     @createTransactionResponse.profileResponse.messages.resultCode.should == actResponse.profileResponse.messages.resultCode
     @createTransactionResponse.profileResponse.messages.messages.each_with_index do |item,index|


### PR DESCRIPTION
- Fields of SecureAcceptance class were not accessible in sample code.
- This may be due to the different names of fields of SecureAcceptance class in xsd and schema.rb.
- Changing the field names fixed the issue. 
- Reviewed by: Ashish Kankaria(akankaria)