### PR TITLE
Add solution id to the AIM transaction objects

### DIFF
--- a/authorizenet.gemspec
+++ b/authorizenet.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "authorizenet"
-  s.version = "1.8.5.3"
+  s.version = "1.8.5.4"
   s.platform = Gem::Platform::RUBY
   s.date = "2015-08-11"
   s.summary = "Authorize.Net Payments SDK"

--- a/lib/authorize_net/aim/transaction.rb
+++ b/lib/authorize_net/aim/transaction.rb
@@ -71,6 +71,7 @@ module AuthorizeNet::AIM
       @verify_ssl = options[:verify_ssl]
       @market_type = options[:market_type]
       @device_type = options[:device_type]
+      @solution_id = options[:solution_id]
     end
     
     # Checks if the transaction has been configured for test mode or not. Return TRUE if the
@@ -127,6 +128,10 @@ module AuthorizeNet::AIM
     def cp_version
       @cp_version
     end
+
+    def solution_id
+      @solution_id
+    end
     
     #:enddoc:
     protected
@@ -147,6 +152,7 @@ module AuthorizeNet::AIM
       fields[:test_request] = boolean_to_value(@test_mode)
       fields[:allow_partial_auth] = 'TRUE' if @allow_split_transaction
       fields[:encap_char] = @encapsulation_character unless @encapsulation_character.nil?
+      fields[:solution_id] = @solution_id unless @solution_id.nil?
       fields.each do |k, v|
         if @@boolean_fields.include?(k)
           fields[k] = boolean_to_value(v)

--- a/lib/authorize_net/api/schema.rb
+++ b/lib/authorize_net/api/schema.rb
@@ -1176,8 +1176,8 @@ end
     xml_accessor :description
     xml_accessor :email
     xml_accessor :customerProfileId
-    xml_accessor :paymentProfiles
-    xml_accessor :shipToList
+    xml_accessor :paymentProfiles, :from => 'paymentProfiles' , :as => [CustomerPaymentProfileMaskedType]
+    xml_accessor :shipToList, :from => 'shipToList' , :as => [CustomerAddressExType]
   
     def initialize(merchantCustomerId = nil, description = nil, email = nil, customerProfileId = nil, paymentProfiles = [], shipToList = [])
       @merchantCustomerId = merchantCustomerId

--- a/lib/authorize_net/fields.rb
+++ b/lib/authorize_net/fields.rb
@@ -49,6 +49,7 @@ module AuthorizeNet
         :md5_hash,
         :card_code_response,
         :cardholder_authentication_verification_response,
+        :solution_id,
         nil,
         nil,
         nil,

--- a/spec/aim_spec.rb
+++ b/spec/aim_spec.rb
@@ -8,6 +8,7 @@ describe AuthorizeNet::AIM::Transaction do
       @api_key = creds['api_transaction_key']
       @api_login = creds['api_login_id']
       @md5_value = creds['md5_value']
+      @solution_id = "AAA100302"
     rescue Errno::ENOENT => e
       @api_key = "TEST"
       @api_login = "TEST"
@@ -183,6 +184,14 @@ describe AuthorizeNet::AIM::Transaction do
     transaction.set_shipping_address(address)
     transaction.purchase(@amount, @credit_card).should be_kind_of(AuthorizeNet::AIM::Response)
     transaction.response.success?.should be_truthy
+  end
+
+  it "should support setting solution id" do
+    transaction = AuthorizeNet::AIM::Transaction.new(@api_login, @api_key, :transaction_type => @type, :gateway => @gateway, :test => @test_mode, :solution_id => @solution_id)
+    transaction.purchase(@amount, @credit_card).should be_kind_of(AuthorizeNet::AIM::Response)
+    transaction.response.success?.should be_truthy
+    fields = transaction.response.transaction
+    (defined?(fields.solution_id) and fields.solution_id == 'AAA100302').should be_truthy
   end
   
   it "should support adding an email receipt" do

--- a/spec/cim_spec.rb
+++ b/spec/cim_spec.rb
@@ -453,6 +453,17 @@ describe AuthorizeNet::CIM::Transaction do
     expect(response.success?).to eq true
     expect(response.profile_ids).not_to eq nil
   end
+  
+  it "should be able to get zero profile ids when a merchant has zero customer profiles" do
+    #Using specific credentials for a Merchant which has zero customer profiles
+    #NOTE: These credentials are specific to this test
+    transaction = AuthorizeNet::CIM::Transaction.new("3qkNY3db6jB", "7s8B76QvsPet82HH", :gateway => :sandbox)
+    expect(transaction).to respond_to(:get_profile_ids)
+    response = transaction.get_profile_ids
+    expect(response).to be_kind_of(AuthorizeNet::CIM::Response)
+    expect(response.success?).to eq true
+    expect(response.profile_ids).to eq nil
+  end
 end
 
 describe AuthorizeNet::CIM::Response do


### PR DESCRIPTION
Solution id provides the functionality to review transactions on the basis of single id for a partner developer. So adding an option to provide the solution_id when the transaction is created in old model for AIM transactions. Also adding a test case to check the solution_id is set properly from the response returned from the server.