### PR TITLE
Get transaction list

### DIFF
--- a/lib/authorize_net/api/transaction.rb
+++ b/lib/authorize_net/api/transaction.rb
@@ -207,5 +207,13 @@ module AuthorizeNet::API
     def arb_get_subscription_request(request)  
       make_request(request,ARBGetSubscriptionResponse,Type::API_ARB_GET_SUBSCRIPTION_REQUEST)
     end
+
+    # This request enables you to get transaction list
+    #
+    # See spec/api_spec.rb for usage examples
+    def get_transaction_list(request)
+      make_request(request,GetTransactionListResponse,Type::API_GET_TRANSACTION_LIST)
+    end
+
   end
 end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -542,6 +542,25 @@ describe Transaction do
     expect(response.paymentProfiles.paymentProfile[0].payment.creditCard.cardNumber).not_to eq(nil) 
         
   end
+
+  it "should be able to get transaction List Request" do
+    transaction = AuthorizeNet::API::Transaction.new(@api_login, @api_key, :gateway => @gateway)
+
+    batchId = "4551107"
+
+    @getTransactionListRequest = GetTransactionListRequest.new
+    @getTransactionListRequest.batchId = batchId
+
+    transaction.should respond_to(:get_transaction_list)
+    response = transaction.get_transaction_list(@getTransactionListRequest)
+
+    expect(response).not_to eq(nil)
+    expect(response.messages).not_to eq(nil)
+    expect(response.messages.resultCode).not_to eq(nil)
+    expect(response.messages.resultCode).to eq(MessageTypeEnum::Ok)
+    expect(response.transactions).not_to eq (nil)
+
+  end
   
   def get_actual(expected, className, topElement)
     xmlText = @transaction.serialize(expected,topElement)


### PR DESCRIPTION
The samples had been using the older reporting API till now for retrieving the transaction list. This adds the API call to retrieve transaction list corresponding to a batch id through new API.
Also adds a unit test to test the feature.