### PR TITLE
Updated schema.rb for correct serialization

### DIFF
--- a/lib/authorize_net/api/schema.rb
+++ b/lib/authorize_net/api/schema.rb
@@ -1183,8 +1183,8 @@ end
     xml_accessor :merchantCustomerId
     xml_accessor :description
     xml_accessor :email
-    xml_accessor :paymentProfiles
-    xml_accessor :shipToList
+    xml_accessor :paymentProfiles, :from => 'paymentProfiles', :as => [CustomerPaymentProfileType]
+    xml_accessor :shipToList, :from => 'shipToList', :as => [CustomerAddressType]
   
     def initialize(merchantCustomerId = nil, description = nil, email = nil, paymentProfiles = [], shipToList = [])
       @merchantCustomerId = merchantCustomerId
@@ -2961,8 +2961,8 @@ end
     xml_accessor :messages, :as => MessagesType
     xml_accessor :sessionToken
     xml_accessor :customerProfileId
-    xml_accessor :customerPaymentProfileIdList
-    xml_accessor :customerShippingAddressIdList
+    xml_accessor :customerPaymentProfileIdList, :as => NumericStringsType
+    xml_accessor :customerShippingAddressIdList, :as => NumericStringsType
     xml_accessor :validationDirectResponseList
   
     def initialize(refId = nil, messages = nil, sessionToken = nil, customerProfileId = nil, customerPaymentProfileIdList = nil, customerShippingAddressIdList = nil, validationDirectResponseList = nil)


### PR DESCRIPTION
When using CreateCustomerProfileRequest and passing payment profile into CustomerProfileType, the paymentProfiles doesn't get properly serialized.

Same problem when getting the payment profile id from the response, the id should be in the numericString list

Code snippet when problem happened:

```
request = CreateCustomerProfileRequest.new

payment = PaymentType.new(CreditCardType.new('4111111111111111','2020-05'))
profile = CustomerPaymentProfileType.new(nil,nil,payment,nil,nil)

request.profile = CustomerProfileType.new(
      user.id.to_s,         # merchantCustomerId
      user.display_name,    # description
      user.email,           # email
      [profile],            # paymentProfiles
      nil)                  # shipToList

response = transaction.create_customer_profile(request)
```

Using above code will return error:
`The element 'paymentProfiles' in namespace 'AnetApi/xml/v1/schema/AnetApiSchema.xsd' cannot contain text. List of possible elements expected: 'customerType, billTo, payment, driversLicense, taxId' in namespace 'AnetApi/xml/v1/sch
ema/AnetApiSchema.xsd'.`
