### PR TITLE
Support Rails 5 by (soft) dropping support for Ruby 2.1

### DIFF
--- a/authorizenet.gemspec
+++ b/authorizenet.gemspec
@@ -14,11 +14,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = '>= 2.1.0'
   s.required_rubygems_version = '>= 1.3.6'
 
-  if RUBY_VERSION  < '2.2'
-    s.add_runtime_dependency 'activesupport', '= 4.2.6'
-  else
-    s.add_runtime_dependency 'activesupport', '>= 4.2.6'
-  end
+  s.add_runtime_dependency 'activesupport', '>= 4.2.6'
   s.add_runtime_dependency 'nokogiri', '~> 1.6', '>= 1.6.4'
   s.add_runtime_dependency "roxml", "= 3.3.1"
 


### PR DESCRIPTION
By not increasing the required Ruby version in the gemspec, this allows users still use Ruby 2.1 while also supporting current technology (2.3).

For 2.1 users, they may need to add a lock to activesupport v4.2.6 in their Gemfile.

By the way, Ruby 2.1 is EOL (see [ruby-lang.org](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/)).

I didn't see a place to report changes like a CHANGES.md. I could add one if you'd like. Or add something to the README.

This probably warrants at least a minor upgrade (e.g. 1.10.0) rather than a patch level (e.g. 1.9.1).
