### PR TITLE
Fix sandbox link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 ````
 ## Registration & Configuration
 
-Get a sandbox account at https://developer.authorize.net/sandbox/
+Get a sandbox account at https://developer.authorize.net/hello_world/sandbox/
 To run rspec tests, create a spec/credentials.yml with the following keys and the values obtained as described below.
 ````
 #obtain an API login_id and transaction_id according to instructions at https://developer.authorize.net/faqs/#gettranskey


### PR DESCRIPTION
I noticed the sandbox link in the README is broken (infinite redirect)

![screen shot 2017-05-30 at 2 28 13 pm](https://cloud.githubusercontent.com/assets/79619/26601115/4bee57f6-4544-11e7-9346-d432be6bf829.png)

Looks like the current link redirects to https://developer.authorize.net/hello_world/sandbox (without trailing slash). It appears that for the link to work there must be a trailing slash. 😂 