### PR TITLE
fix invalid gemspec

### DIFF
--- a/authorizenet.gemspec
+++ b/authorizenet.gemspec
@@ -14,11 +14,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = '>= 2.1.0'
   s.required_rubygems_version = '>= 1.3.6'
 
-  if RUBY_VERSION  < '2.2'
-    s.add_runtime_dependency 'activesupport', '= 4.2.6'
-  else
-    s.add_runtime_dependency 'activesupport', '>= 4.2.6'
-  end
+  s.add_runtime_dependency 'activesupport', '>= 4.2.6'
   s.add_runtime_dependency 'nokogiri', '~> 1.6', '>= 1.6.4'
   s.add_runtime_dependency "roxml", "= 3.3.1"
 


### PR DESCRIPTION
The .gemspec file is evaluated when the gem is cut and the output is saved in
the gem, it is not evaluated when the gem is installed or when bundler is
resolving dependencies.

The way the gemspec was previously written, then, evaluated to a different
activesupport dependency based on what ruby version cut the gem - it had
no effect on users of the gem.  A completely different gem gets cut
depending on what version of ruby cuts it - which is not desirable behavior,
and it prevents anyone from using it with any rails version besides 4.2.6,
regardless of ruby version.

If there's a reason to limit ruby 2.1 users to activesupport 4.2.6, we can
communicate that in the README, but we can't specify it in the gem like this.

See https://stackoverflow.com/questions/41687102/how-to-add-conditional-gemspec-dependencies for more info.