### PR TITLE
Add missing subscription class in api schema

### DIFF
--- a/lib/authorize_net/api/schema.rb
+++ b/lib/authorize_net/api/schema.rb
@@ -1698,7 +1698,7 @@ end
     xml_accessor :marketType
     xml_accessor :product
     xml_accessor :mobileDeviceId
-    xml_accessor :subscription
+    xml_accessor :subscription, :as => SubscriptionPaymentType
     xml_accessor :hasReturnedItems
     xml_accessor :fraudInformation
 	xml_accessor :profile, :as => CustomerProfileIdType
@@ -1967,7 +1967,7 @@ end
     xml_accessor :transactionStatus
     xml_accessor :responseCode
     xml_accessor :responseReasonCode
-    xml_accessor :subscription
+    xml_accessor :subscription, :as => SubscriptionPaymentType
     xml_accessor :responseReasonDescription
     xml_accessor :authCode
     xml_accessor :aVSResponse


### PR DESCRIPTION
In `lib/authorize_net/api/schema.rb` lines [#1682](https://github.com/AuthorizeNet/sdk-ruby/blob/master/lib/authorize_net/api/schema.rb#L1682) and [#1905](https://github.com/AuthorizeNet/sdk-ruby/blob/master/lib/authorize_net/api/schema.rb#L1905) the class type for the subscription is `SubscriptionPaymentType` but the `xml_accessor :subscription` does not have it and when deserializing from the xml the subscription is mixing the subscription `id` with the `payNum`

I am using `GetTransactionListRequest` for getting the transactions, these transactions are type of `TransactionSummaryType`, when asking from `transaction.subscription` is it returning an `string` like `"41122342"` where `4112234` is the subscription id and the last character `2` is the `payNum`.

The expected result should be that `transaction.subscription` returns a `SubscriptionPaymentType` object, not a string.