### PR TITLE
unlock roxml dependency

### DIFF
--- a/authorizenet.gemspec
+++ b/authorizenet.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'activesupport', '>= 4.2.6'
   s.add_runtime_dependency 'nokogiri', '~> 1.6', '>= 1.6.4'
-  s.add_runtime_dependency "roxml", "= 3.3.1"
+  s.add_runtime_dependency 'roxml', '~> 3.3', '>= 3.3.1'
 
   s.add_development_dependency 'rake', '~> 0.8', '>= 0.8.7'
   s.add_development_dependency 'rspec', '~> 2.1'


### PR DESCRIPTION
This PR unlocks the dependency on roxml, so when 3.3.2 is released it can be used as well.  The updated version includes some changes that remove deprecation warnings for ruby 2.4 users.  I have been working with the maintainer on that gem to clean up the PR backlog so we can release that soon.

This also resolves #136