### PR TITLE
allow roxml 4.0.0

### DIFF
--- a/authorizenet.gemspec
+++ b/authorizenet.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'activesupport', '>= 4.2.6'
   s.add_runtime_dependency 'nokogiri', '~> 1.6', '>= 1.6.4'
-  s.add_runtime_dependency 'roxml', '~> 3.3', '>= 3.3.1'
+  s.add_runtime_dependency 'roxml', '>= 3.3.1'
 
   s.add_development_dependency 'rake', '~> 0.8', '>= 0.8.7'
   s.add_development_dependency 'rspec', '~> 2.1'


### PR DESCRIPTION
I apologize, the updated roxml has been released as 4.0.0, so we didn't unlock this dep far enough on #138.

There's not supposed to be any breaking changes in roxml, I believe the major version bump was just done out of an abundance of caution since there hasn't been a release in 5+ years.