### PR TITLE
Fix parsing of custom fields in transaction response

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,5 @@ before_script:
 script:
   - bundle exec rake spec:ci
   - bundle exec rake spec:api
+  - bundle exec rake spec:cim
   - bundle exec rake spec:testrunner

--- a/lib/authorize_net/fields.rb
+++ b/lib/authorize_net/fields.rb
@@ -57,7 +57,6 @@ module AuthorizeNet
         nil,
         nil,
         nil,
-        nil,
         :account_number,
         :card_type,
         :split_tender_id,


### PR DESCRIPTION
Pull request #59 should have replaced a row in the fields array instead of inserting a new one.  This was causing CIM specs to fail but they were being ignored.