### PR TITLE
Fix parsing of solution id from transaction details

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,5 @@ script:
   - bundle exec rake spec:ci
   - bundle exec rake spec:api
   - bundle exec rake spec:cim
+  - bundle exec rake spec:reporting
   - bundle exec rake spec:testrunner

--- a/lib/authorize_net/reporting/response.rb
+++ b/lib/authorize_net/reporting/response.rb
@@ -136,7 +136,7 @@ module AuthorizeNet::Reporting
         solution = @transaction.at_css('solution')
         unless solution.nil?
           solution_id = node_content_unless_nil(@transaction.at_css('solution').at_css('id'))
-          transaction.solution_id = value_to_decimal(solution_id) unless solution_id.nil?
+          transaction.solution_id = solution_id unless solution_id.nil?
 
           transaction.solution_name = node_content_unless_nil(@transaction.at_css('solution').at_css('name'))
         end


### PR DESCRIPTION
Solution IDs do not have to be numeric so don't try to coerce them.  Add the reporting specs to Travis now that they all pass.