### PR TITLE
Replace hard coded test account credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 Gemfile.lock
-spec/credentials.yml
 .ruby-*
 .idea
 gemfiles/*.lock

--- a/spec/aim_spec.rb
+++ b/spec/aim_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe AuthorizeNet::AIM::Transaction do
   before :all do
     begin
-      creds = YAML.load_file(File.dirname(__FILE__) + "/credentials.yml")
+      creds = credentials
       @api_key = creds['api_transaction_key']
       @api_login = creds['api_login_id']
       @md5_value = creds['md5_value']
@@ -285,7 +285,7 @@ end
 describe AuthorizeNet::AIM::Response do
   before :all do
     begin
-      creds = YAML.load_file(File.dirname(__FILE__) + "/credentials.yml")
+      creds = credentials
       @api_key = creds['api_transaction_key']
       @api_login = creds['api_login_id']
     rescue Errno::ENOENT => e

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -4,7 +4,7 @@ include  AuthorizeNet::API
 describe Transaction do
   before :all do
     begin
-      creds = YAML.load_file(File.dirname(__FILE__) + "/credentials.yml")
+      creds = credentials
       @api_key = creds['api_transaction_key']
       @api_login = creds['api_login_id']
       @gateway = :sandbox

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -158,7 +158,7 @@ describe Transaction do
 
     expect(createProfResp).not_to eq(nil)
     unless createProfResp.messages.resultCode == MessageTypeEnum::Ok
-      puts createProfResp.messages.messages[0].text
+      puts createProfResp.messages.messages[0].text, createProfReq.transId
     end
     expect(createProfResp.messages.resultCode).to eq(MessageTypeEnum::Ok)
     expect(createProfResp.customerProfileId).not_to eq(nil)

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -484,6 +484,7 @@ describe Transaction do
   end
 
   it "should be able to get subscription" do
+    @api_login, @api_key = '5KP3u95bQpv', '346HZ32z3fP4hTG2' # FIXME: this spec added in #66 depends on a hard coded test account.
     transaction = AuthorizeNet::API::Transaction.new(@api_login, @api_key, gateway: @gateway)
     @createTransactionRequest = ARBGetSubscriptionRequest.new
 
@@ -505,6 +506,7 @@ describe Transaction do
   end
 
   it "should be able to get Customer Payment Profile List Request" do
+    @api_login, @api_key = '5KP3u95bQpv', '346HZ32z3fP4hTG2' # FIXME: this spec added in #66 depends on a hard coded test account.
     transaction = AuthorizeNet::API::Transaction.new(@api_login, @api_key, gateway: @gateway)
 
     searchTypeEnum = CustomerPaymentProfileSearchTypeEnum::CardsExpiringInMonth
@@ -538,6 +540,7 @@ describe Transaction do
   end
 
   it "should be able to get transaction List Request" do
+    @api_login, @api_key = '5KP3u95bQpv', '346HZ32z3fP4hTG2' # FIXME: this spec added in #72 depends on a hard coded test account.
     transaction = AuthorizeNet::API::Transaction.new(@api_login, @api_key, gateway: @gateway)
 
     batchId = "4551107"

--- a/spec/arb_spec.rb
+++ b/spec/arb_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe AuthorizeNet::ARB::Transaction do
   before :all do
     begin
-      creds = YAML.load_file(File.dirname(__FILE__) + "/credentials.yml")
+      creds = credentials
       @api_key = creds['api_transaction_key']
       @api_login = creds['api_login_id']
     rescue Errno::ENOENT => e

--- a/spec/cim_spec.rb
+++ b/spec/cim_spec.rb
@@ -253,6 +253,7 @@ describe AuthorizeNet::CIM::Transaction do
         transaction = AuthorizeNet::CIM::Transaction.new(api_login, api_key, gateway: :sandbox)
         expect(transaction).to respond_to(:create_transaction_auth_only)
         response = transaction.create_transaction_auth_only(@amount, profile, payment_profile, AuthorizeNet::Order.new)
+        expect(response.message_text).to eq 'Successful.'
         expect(response.success?).to eq true
         direct_response = response.direct_response
         expect(direct_response).to be_instance_of(AuthorizeNet::AIM::Response)
@@ -263,6 +264,7 @@ describe AuthorizeNet::CIM::Transaction do
         # create an auth only transaction
         transaction = AuthorizeNet::CIM::Transaction.new(api_login, api_key, gateway: :sandbox)
         response = transaction.create_transaction_auth_only(@amount + 10, profile, payment_profile, AuthorizeNet::Order.new)
+        expect(response.message_text).to eq 'Successful.'
         expect(response.success?).to eq true
         direct_response = response.direct_response
         expect(direct_response.success?).to eq true
@@ -281,6 +283,7 @@ describe AuthorizeNet::CIM::Transaction do
         # create a transaction
         transaction = AuthorizeNet::CIM::Transaction.new(api_login, api_key, gateway: :sandbox)
         response = transaction.create_transaction_auth_capture(@amount, profile, payment_profile, AuthorizeNet::Order.new)
+        expect(response.message_text).to eq 'Successful.'
         expect(response.success?).to eq true
         direct_response = response.direct_response
         expect(direct_response.success?).to eq true
@@ -326,6 +329,7 @@ describe AuthorizeNet::CIM::Transaction do
       it "should support custom fields" do
         transaction = AuthorizeNet::CIM::Transaction.new(api_login, api_key, gateway: :sandbox)
         response = transaction.create_transaction_auth_capture(@amount, profile, payment_profile, AuthorizeNet::Order.new, custom_fields: { foo: '123', bar: '456' })
+        expect(response.message_text).to eq 'Successful.'
         expect(response.success?).to eq true
         direct_response = response.direct_response
         expect(direct_response.success?).to eq true
@@ -341,6 +345,7 @@ describe AuthorizeNet::CIM::Transaction do
         order.description = 'This order includes invoice num'
         order.po_num = 'PO_12345'
         response = transaction.create_transaction_auth_capture(@amount, profile, payment_profile, order)
+        expect(response.message_text).to eq 'Successful.'
         expect(response.success?).to eq true
         direct_response = response.direct_response
         expect(direct_response).to be_instance_of(AuthorizeNet::AIM::Response)

--- a/spec/credentials.yml
+++ b/spec/credentials.yml
@@ -1,5 +1,6 @@
 #obtain an API login_id and transaction_id according to instructions at https://developer.authorize.net/faqs/#gettranskey
-api_login_id: 5KP3u95bQpv
-api_transaction_key: 346HZ32z3fP4hTG2
+api_login_id: <%= ENV.fetch 'API_LOGIN_ID' %>
+api_transaction_key: <%= ENV.fetch 'API_TRANSACTION_KEY' %>
+
 #obtained md5 hash value by first setting the hash value in https://sandbox.authorize.net/ under the Account tab->MD5 Hash
-md5_value: MD5_TEST
+md5_value: <%= ENV['MD5_VALUE'] || 'MD5_TEST' %>

--- a/spec/reporting_spec.rb
+++ b/spec/reporting_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe AuthorizeNet::Reporting do
   before :all do
     begin
-      creds = YAML.load_file(File.dirname(__FILE__) + "/credentials.yml")
+      creds = credentials
       @api_key = creds['api_transaction_key']
       @api_login = creds['api_login_id']
     rescue Errno::ENOENT => e

--- a/spec/sim_spec.rb
+++ b/spec/sim_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe AuthorizeNet::SIM::Transaction do
   before :all do
     begin
-      creds = YAML.load_file(File.dirname(__FILE__) + "/credentials.yml")
+      creds = credentials
       @api_key = creds['api_transaction_key']
       @api_login = creds['api_login_id']
     rescue Errno::ENOENT => e
@@ -53,7 +53,7 @@ end
 describe AuthorizeNet::SIM::Response do
   before :all do
     begin
-      creds = YAML.load_file(File.dirname(__FILE__) + "/credentials.yml")
+      creds = credentials
       @api_key = creds['api_transaction_key']
       @api_login = creds['api_login_id']
     rescue Errno::ENOENT => e

--- a/spec/support/shared_helper.rb
+++ b/spec/support/shared_helper.rb
@@ -1,6 +1,9 @@
+require 'erb'
+require 'yaml'
+
 module SharedHelper
   def credentials
-    $credentials ||= YAML.load_file(File.dirname(__FILE__) + "/../credentials.yml")
+    $credentials ||= YAML.load(ERB.new(File.read "#{__dir__}/../credentials.yml").result)
   rescue Errno::ENOENT
     warn "WARNING: Running w/o valid AuthorizeNet sandbox credentials. Create spec/credentials.yml."
   end


### PR DESCRIPTION
Replaces the default hard coded credentials with environment variables.

To run tests locally you can either update credentials.yml or set API_LOGIN_KEY and API_TRANSACTION_KEY.  To run tests on Travis CI set API_LOGIN_KEY and API_TRANSACTION_KEY in the Travis project settings.