### PR TITLE
Clarify that the old APIs have been deprecated.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![Coverage        ][coverage_badge]][coverage]
 [![Scrutinizer     ][scrutinizer_badge]][scrutinizer]
 
+Starting Release 1.8.6 November 2015 the Authorize.Net API has been [reorganized to be more merchant focused](https://developer.authorize.net/api/upgrade_guide/).
+AIM, ARB, CIM, Reporting and SIM have all been deprecated in favor of AuthorizeNet::API.
+
 ## Requirements
 * Ruby 2.2.2 or higher
 * RubyGem 1.3.7 or higher (to build the gem)

--- a/lib/authorize_net/aim/transaction.rb
+++ b/lib/authorize_net/aim/transaction.rb
@@ -41,6 +41,7 @@ module AuthorizeNet::AIM
     # +market_type+:: A constant from MarketType indicating your industry. Used for card present transactions. Defaults to MarketType::RETAIL.
     #
     def initialize(api_login_id, api_transaction_key, options = {})
+      ActiveSupport::Deprecation.warn "use AuthorizeNet::API::Transaction"
       super()
       options = @@option_defaults.merge(options)
       @api_login_id = api_login_id

--- a/lib/authorize_net/arb/transaction.rb
+++ b/lib/authorize_net/arb/transaction.rb
@@ -36,6 +36,7 @@ module AuthorizeNet::ARB
     # +reference_id+:: A string that can be used to identify a particular transaction with its response. Will be echo'd in the response, only if it was provided in the transaction. Defaults to nil.
     #
     def initialize(api_login_id, api_transaction_key, options = {})
+      ActiveSupport::Deprecation.warn "use AuthorizeNet::API::Transaction"
       super
     end
 

--- a/lib/authorize_net/cim/transaction.rb
+++ b/lib/authorize_net/cim/transaction.rb
@@ -27,6 +27,7 @@ module AuthorizeNet::CIM
     # +reference_id+:: A string that can be used to identify a particular transaction with its response. Will be echo'd in the response, only if it was provided in the transaction. Defaults to nil.
     #
     def initialize(api_login_id, api_transaction_key, options = {})
+      ActiveSupport::Deprecation.warn "use AuthorizeNet::API::Transaction"
       super
       @delim_char = ','
       @encap_char = nil

--- a/lib/authorize_net/reporting/transaction.rb
+++ b/lib/authorize_net/reporting/transaction.rb
@@ -23,6 +23,7 @@ module AuthorizeNet::Reporting
     # +reference_id+:: A string that can be used to identify a particular transaction with its response. Will be echo'd in the response, only if it was provided in the transaction. Defaults to nil.
     #
     def initialize(api_login_id, api_transaction_key, options = {})
+      ActiveSupport::Deprecation.warn "use AuthorizeNet::API::Transaction"
       super
     end
 

--- a/lib/authorize_net/sim/transaction.rb
+++ b/lib/authorize_net/sim/transaction.rb
@@ -40,6 +40,7 @@ module AuthorizeNet::SIM
     # +transaction_type+:: The type of transaction to perform. Defaults to AuthorizeNet::Type::AUTHORIZE_AND_CAPTURE. This value is only used if run is called directly.
     #
     def initialize(api_login_id, api_transaction_key, amount, options = {})
+      ActiveSupport::Deprecation.warn "use AuthorizeNet::API::Transaction"
       super()
       @api_transaction_key = api_transaction_key
       @api_login_id = api_login_id

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,13 @@ Scrutinizer::Ocular.watch!
 require "authorizenet"
 require "yaml"
 
+ActiveSupport::Deprecation.behavior = lambda do |msg, stack|
+  # when running this test suite ignore our own deprecation warnings
+  unless /use AuthorizeNet::API::Transaction/ =~ msg
+    ActiveSupport::Deprecation::DEFAULT_BEHAVIORS[:stderr].call(msg,stack)
+  end
+end
+
 Dir['./spec/support/**/*.rb'].each { |f| require f }
 
 RSpec.configure do |config|


### PR DESCRIPTION
This is covered in the online documentation for new users but nowhere in the SDK itself for existing Ruby users.