### PR TITLE
Fixed type for customerProfileId in request.

### DIFF
--- a/authorizenet.gemspec
+++ b/authorizenet.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "authorizenet"
-  s.version = "2.0.0"
+  s.version = "2.0.1"
   s.platform = Gem::Platform::RUBY
   s.date = "2019-03-05"
   s.summary = "Authorize.Net Payments SDK"

--- a/lib/authorize_net/api/constants.yml
+++ b/lib/authorize_net/api/constants.yml
@@ -1,1 +1,1 @@
-clientId: sdk-ruby-2.0.0
+clientId: sdk-ruby-2.0.1

--- a/lib/authorize_net/api/schema.rb
+++ b/lib/authorize_net/api/schema.rb
@@ -3454,7 +3454,7 @@ end
   #   refId - SOAP::SOAPString
   #   transId - (any)
   #   customer - CustomerProfileBaseType
-  #   customerProfileId - NumericStringsType
+  #   customerProfileId - (any)
   #   profileType - CustomerProfileTypeEnum
   class CreateCustomerProfileFromTransactionRequest
     include ROXML
@@ -3462,7 +3462,7 @@ end
     xml_accessor :refId
     xml_accessor :transId
     xml_accessor :customer, as: CustomerProfileBaseType
-    xml_accessor :customerProfileId, as: NumericStringsType
+    xml_accessor :customerProfileId
     xml_accessor :defaultPaymentProfile
     xml_accessor :defaultShippingAddress
     xml_accessor :profileType


### PR DESCRIPTION
In CreateCustomerProfileFromTransactionRequest the customerProfileId was
improperly specified as a NumericStringsType.  This commit removes the
designation.

Note that in some places customerProfileId is specified as an Integer,
which is correct.  There should probably be consistency applied.

Closes #180.