### PR TITLE
GENAI| fix: replace unsafe YAML deserialization with safe_load methods

### DIFF
--- a/lib/authorize_net/api/LogHelper.rb
+++ b/lib/authorize_net/api/LogHelper.rb
@@ -10,7 +10,7 @@ class Log
         begin	
 	    filepath = './LogConfig.yml'
 	    if(File.file?(filepath))
-		cnf = YAML::load(File.open(filepath))
+		cnf = YAML.safe_load(File.open(filepath))
 		if(@@loglevels.include? cnf['loglevel'].downcase)
 			@@shouldLog = true
 			@logger = Logger.new(cnf['filepath'])
@@ -18,7 +18,7 @@ class Log
 			if(cnf['maskSensitiveData'])
 		            @logger.formatter = SensitiveDataFilter.new 
 			else
-      			      constants = YAML.load_file(File.dirname(__FILE__) + "/constants.yml")
+      		      constants = YAML.safe_load_file(File.dirname(__FILE__) + "/constants.yml")
 			      @logger.formatter = proc do |severity, datetime, progname, msg|
 			      progname = constants['clientId']
 		              date_format = datetime.strftime("%Y-%m-%d %H:%M:%S")

--- a/lib/authorize_net/api/SensitiveDataFilter.rb
+++ b/lib/authorize_net/api/SensitiveDataFilter.rb
@@ -79,7 +79,7 @@ class SensitiveDataFilter < Logger::Formatter
 	end
 
 	def formatLogEntry(severity, time, progname, msg)
-              constants = YAML.load_file(File.dirname(__FILE__) + "/constants.yml")
+              constants = YAML.safe_load_file(File.dirname(__FILE__) + "/constants.yml")
 	      progname = constants['clientId']
               date_format = time.strftime("%Y-%m-%d %H:%M:%S")
 	      if severity == "INFO" or severity == "WARN"

--- a/lib/authorize_net/api/api_transaction.rb
+++ b/lib/authorize_net/api/api_transaction.rb
@@ -85,7 +85,7 @@ module AuthorizeNet::API
     def serialize(object, type)
       doc = Nokogiri::XML::Document.new
       doc.root = object.to_xml
-      constants = YAML.load_file(File.dirname(__FILE__) + "/constants.yml")
+      constants = YAML.safe_load_file(File.dirname(__FILE__) + "/constants.yml")
       clientId = constants['clientId']
 
       builder = Nokogiri::XML::Builder.new(encoding: 'utf-8') do |x|

--- a/spec/support/shared_helper.rb
+++ b/spec/support/shared_helper.rb
@@ -3,7 +3,7 @@ require 'yaml'
 
 module SharedHelper
   def credentials
-    $credentials ||= YAML.load(ERB.new(File.read "#{__dir__}/../credentials.yml").result)
+    $credentials ||= YAML.safe_load(ERB.new(File.read "#{__dir__}/../credentials.yml").result)
   rescue Errno::ENOENT
     warn "WARNING: Running w/o valid AuthorizeNet sandbox credentials. Create spec/credentials.yml."
   end


### PR DESCRIPTION
Prevent RCE attacks by using YAML.safe_load instead of YAML.load in LogHelper.rb (lines 13, 20)